### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeberg.yml
+++ b/.github/workflows/codeberg.yml
@@ -1,4 +1,6 @@
 name: Mirror to Codeberg
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/KIB-in-Batch/kib-in-batch/security/code-scanning/5](https://github.com/KIB-in-Batch/kib-in-batch/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow, ideally at the root level but possibly at the job level if future jobs might have different needs. For this specific workflow, the minimal privilege required is likely just `contents: read`, as the workflow simply checks out code and pushes it to Codeberg using a secret token. To implement the change, insert the following block at the root of the YAML workflow, directly below the workflow `name`. No new imports or methods are required; only the YAML file needs updating.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
